### PR TITLE
Contact Manager: change current_user so it actually returns nil

### DIFF
--- a/source/projects/contact_manager.markdown
+++ b/source/projects/contact_manager.markdown
@@ -2322,11 +2322,11 @@ Open up `app/controllers/application_controller.rb` and add the following to it:
 helper_method :current_user
 
 def current_user
-  @current_user ||= User.find(session[:user_id])
+  @current_user ||= User.where(id: session[:user_id]).take
 end
 ```
 
-The test fails because when we say `User.find(session[:user_id])` this comes back as nil.
+The test fails because when we say `User.where(id: session[:user_id]).take` this comes back as nil.
 
 Let's put the user id in the session. Go back to the sessions controller and update the `create` method:
 


### PR DESCRIPTION
User.find(session[:user_id]) doesn't actually return nil, it throws the following error: 
Failure/Error: expect(controller.current_user.id).to eq(user.id)
     ActiveRecord::RecordNotFound:
       Couldn't find User without an ID

If we actually want nil (which we probably do if we want a falsey value for if statements later) we can do User.where(id: session[:user_id]).take.

@stevekinney (I saw you post in 1407 that we can tag  you, so I am :P Not sure if this is what you meant.)