### PR TITLE
Fixing typo in static_pages.markdown

### DIFF
--- a/source/topics/blogger/static_pages.markdown
+++ b/source/topics/blogger/static_pages.markdown
@@ -207,7 +207,7 @@ def show
 end
 ```
 
-A model's `find` method by default is searching the databaes by the id. We could
+A model's `find` method by default is searching the databases by the id. We could
 change that to instead search by **slug**.
 
 ```ruby


### PR DESCRIPTION
Found one typo, databaes -> databases