### PR TITLE
Update blogger.markdown

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -2247,7 +2247,7 @@ the show page for our new Author user.
 
 Now it's displaying the password and password_confirmation text here, lets delete that! Edit your `app/views/authors/show.html.erb` page to remove those from the display.
 
-If you click _Back_, you'll see that the `app/views/authors/index.html.erb` page also shows the hash and salt. Edit the file to remove these as well.
+If you click _Back_, you'll see that the `app/views/authors/index.html.erb` page also shows the password and password_confirmation. Edit the file to remove these as well.
 
 We can see that we've created a user record in the system, but we can't really tell if we're logged in. Sorcery provides a couple of methods for our views that can help us out: `current_user` and `logged_in?`. The `current_user` method will return the currently logged-in user if one exists and `false` otherwise, and `logged_in?` returns `true` if a user is logged in and `false` if not.
 


### PR DESCRIPTION
In the authentication section, on line 2250, contains "...index.html.erb page also shows the hash and salt.". From my understanding it should be password and password_confirmation instead of hash and salt respectively (thery are different right).