### PR TITLE
Comments are not appearing on the article page

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1297,7 +1297,9 @@ There is one tricky bit, though! We need to assign the article id to our comment
 def create
   @comment = Comment.new(comment_params)
   @comment.article_id = params[:article_id]
-
+  @comment.author_name = params[:comment][:author_name]
+  @comment.body = params[:comment][:body]
+  
   @comment.save
 
   redirect_to article_path(@comment.article)


### PR DESCRIPTION
adding these two lines will allow you to access the author_name and body of the comment params