### PR TITLE
Merchant Tutorial - Iteration 6: Fixes error that (presumably) is due to old syntax being used

### DIFF
--- a/source/projects/merchant.markdown
+++ b/source/projects/merchant.markdown
@@ -1701,9 +1701,9 @@ the lookup:
 
 ```ruby
 def self.find_or_create_by_auth(auth_data)
-  find_or_create_by_provider_and_uid(auth_data["provider"], auth_data["uid"],
-                                     name: auth_data["info"]["name"])
-end
+  where(:auth_data ["provider"], :auth_data["uid"],
+                                     name: auth_data["info"]["name"]).first_or_create
+  end
 ```
 
 That will work great!


### PR DESCRIPTION
I spent quite a while on figuring this one out, but apparently the syntax used for this method is out of date, according to: 

http://stackoverflow.com/questions/3046607/rails-find-or-create-by-more-than-one-attribute/3046645#3046645.

I just started coding and this is my first potential contribution to a relevant repo, so please be gentle. :)