### PR TITLE
Refactored deprecated find_or_initialize_by_id method

### DIFF
--- a/source/topics/controllers/slimming_controllers.markdown
+++ b/source/topics/controllers/slimming_controllers.markdown
@@ -263,7 +263,7 @@ But that's *unnecessary*. You can take advantage of the built in `find_or_initia
 ```ruby
 class ArticlesController < ApplicationController
   def article
-    @cached_article ||= Article.find_or_initialize_by_id(params[:id])
+    @cached_article ||= Article.find_or_initialize_by(id: params[:id])
   end
 
   # ...


### PR DESCRIPTION
Per the [Rails 4.0 Release Notes 11.2 Deprecations](http://guides.rubyonrails.org/4_0_release_notes.html),  `find_or_initialize_by_dynamic_method_name` is deprecated. 

The new syntax `find_or_initialize_by(id: param[:id])` takes a hash as an argument. 

Thanks for the great materials. 